### PR TITLE
Fix Choice of Injection Strategy for Nested Files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - "4"
   - "6"
+  - "8"
 after_success:
   - './node_modules/.bin/nyc report --reporter=text-lcov | ./node_modules/.bin/coveralls'

--- a/lib/fixtures/dir2/MyConstructor.js
+++ b/lib/fixtures/dir2/MyConstructor.js
@@ -1,5 +1,7 @@
-module.exports = function MyConstructor(myFactory, b) {
-  this.name = 'MyConstructor'
-  this.b = b
-  this.myFactory = myFactory
+module.exports = class MyConstructor {
+  constructor(myFactory, b) {
+    this.name = 'MyConstructor'
+    this.b = b
+    this.myFactory = myFactory
+  }
 }

--- a/lib/fixtures/dir3/subdir/MyClass.js
+++ b/lib/fixtures/dir3/subdir/MyClass.js
@@ -1,0 +1,7 @@
+'use strict'
+
+module.exports = class MyClass {
+  constructor(injected) {
+    this.injected = injected
+  }
+}

--- a/lib/fixtures/dir3/subdir/injected.js
+++ b/lib/fixtures/dir3/subdir/injected.js
@@ -1,0 +1,1 @@
+module.exports = 'test message'

--- a/lib/index.js
+++ b/lib/index.js
@@ -16,7 +16,6 @@ module.exports = co.wrap(function* plutoPath(o) {
     const component = components[filename]
 
     const componentName = standardNamingStrategy(filename)
-    // const bindingName = standardBindingStrategy(filename, component)
     const bindingName = standardBindingStrategy(componentName, component)
     bind(componentName)[bindingName](component)
   }

--- a/lib/index.js
+++ b/lib/index.js
@@ -16,7 +16,8 @@ module.exports = co.wrap(function* plutoPath(o) {
     const component = components[filename]
 
     const componentName = standardNamingStrategy(filename)
-    const bindingName = standardBindingStrategy(filename, component)
+    // const bindingName = standardBindingStrategy(filename, component)
+    const bindingName = standardBindingStrategy(componentName, component)
     bind(componentName)[bindingName](component)
   }
   if (options.extraBindings) {

--- a/lib/indexSpec.js
+++ b/lib/indexSpec.js
@@ -7,7 +7,8 @@ const path = require('path')
 const plutoPath = require('./index')
 const fixturesPath = path.join(__dirname, 'fixtures')
 const simpleTestPath = path.join(fixturesPath, 'dir1')
-const complexTextPath = path.join(fixturesPath, 'dir2')
+const complexTestPath = path.join(fixturesPath, 'dir2')
+const nestedTestPath = path.join(fixturesPath, 'dir3')
 
 const simpleBindingMacro = co.wrap(function* (t, input, expected) {
   const app = yield plutoPath(simpleTestPath)
@@ -39,31 +40,38 @@ test('The main function rejects with a meaningful error if given a bad configura
   t.is(error.message, 'options must be a string, array or strings or an object')
 })
 
-test('given complex filex, it binds a non-function object using `toInstance`', function* (t) {
-  const app = yield plutoPath([complexTextPath, simpleTestPath])
+test('given complex files, it binds a non-function object using `toInstance`', function* (t) {
+  const app = yield plutoPath([complexTestPath, simpleTestPath])
   const actual = app.get('myData')
   const expected = require('./fixtures/dir2/innerDir/myData.json')
   t.is(actual, expected)
 })
 
-test('given complex filex, it binds a factory function using `toFactory`', function* (t) {
-  const app = yield plutoPath([complexTextPath, simpleTestPath])
+test('given complex files, it binds a factory function using `toFactory`', function* (t) {
+  const app = yield plutoPath([complexTestPath, simpleTestPath])
   const actual = app.get('myFactory')
   const expected = require('./fixtures/dir2/myFactory')()
   t.is(actual.name, expected.name)
 })
 
-test('given complex filex, it binds a constructor function using `toConstructor`', function* (t) {
+test('given complex files, it binds a constructor function using `toConstructor`', function* (t) {
   const MyConstructor = require('./fixtures/dir2/MyConstructor')
-  const app = yield plutoPath([complexTextPath, simpleTestPath])
+  const app = yield plutoPath([complexTestPath, simpleTestPath])
   const actual = app.get('MyConstructor')
   t.is(actual.name, MyConstructor.name)
   t.truthy(actual instanceof MyConstructor)
 })
 
-test('given complex filex, it binds across modules', function* (t) {
-  const app = yield plutoPath([complexTextPath, simpleTestPath])
+test('given complex files, it binds across modules', function* (t) {
+  const app = yield plutoPath([complexTestPath, simpleTestPath])
   const actual = app.get('MyConstructor')
   const expected = require('./fixtures/dir1/b')()
   t.is(actual.b.name, expected.name)
+})
+
+test('given files in nested folders, it uses the file name and not folder name for determining injection strategy', function* (t) {
+  const app = yield plutoPath(nestedTestPath)
+  const actual = app.get('MyClass')
+  const expectedInjected = require('./fixtures/dir3/subdir/injected')
+  t.is(actual.injected, expectedInjected)
 })

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pluto-path",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Create a Pluto dependency injection module from files in a path or paths",
   "main": "lib/index.js",
   "scripts": {
@@ -10,7 +10,7 @@
     "lint-fix": "eslint . --fix"
   },
   "engines": {
-    "node": ">=4.0.0"
+    "node": ">=6.0.0"
   },
   "homepage": "https://github.com/ecowden/pluto-path",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pluto-path",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Create a Pluto dependency injection module from files in a path or paths",
   "main": "lib/index.js",
   "scripts": {
@@ -11,6 +11,11 @@
   },
   "engines": {
     "node": ">=4.0.0"
+  },
+  "homepage": "https://github.com/ecowden/pluto-path",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/ecowden/pluto-path.git"
   },
   "keywords": [
     "pluto",


### PR DESCRIPTION
When you have a file like `subdir/MyClass.js`, there it will use the path name instead of the file name to choose the injection strategy. In this case, it would see that `subdir` starts with a lowercase letter and decide to use factory injection, when it should see that `MyClass` starts with a capital letter and should use constructor injection.

This PR also bumps Node version dependency to `v6.x`, since I'm using the `class` keyword.